### PR TITLE
Webscraper & OCF Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 slack_webhook.txt
 node_modules
 config.js
+venv

--- a/README.md
+++ b/README.md
@@ -25,4 +25,24 @@ module.exports = {
 
 ```
 
-4. run `npm install` and `node btc_bot.js`. It should send the output to your slack channel.
+4. we rely on env variable `CSV_PATH` to dump our BTC price data. export it now: e.g. `export CSV_PATH="$HOME/public_html/btc-usd.csv"`
+5. run `npm install` and `node btc_bot.js`. It should start appending the price of bitcoin to the csv.
+
+## Scraper
+
+Need python3 env to run all our graphing stuff, easiest way with:
+
+```
+python3 -m venv venv
+pip install -r requirements.txt
+```
+
+Simple e2e test:
+
+```
+./run.sh
+```
+
+* Run `node btc_bot.js` to dump to csv
+* Creates the graph with `write_graph.py` from csv
+* Sends the graph to Slack with `send_slack.js`

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ git clone github.com/gzhao408/cryptobot
 
 ```js
 const SLACK_WEBHOOK = 'YOUR WEBHOOK HERE'
-const CMC_PRO_API_KEY = 'YOUR API KEY HERE'
+const CMC_PRO_API_KEYS = ['YOUR API KEYS HERE']
 
 module.exports = {
   SLACK_WEBHOOK,
-  CMC_PRO_API_KEY
+  CMC_PRO_API_KEYS
 }
 
 ```
 
-4. we rely on env variable `CSV_PATH` to dump our BTC price data. export it now: e.g. `export CSV_PATH="$HOME/public_html/btc-usd.csv"`
+4. we rely on env variable `CSV_PATH` to dump our BTC price data. export it now: e.g. `export CSV_PATH="$HOME/public_html/btc-usd.csv"` or you could just use the e2e script `./run.sh` documented later
 5. run `npm install` and `node btc_bot.js`. It should start appending the price of bitcoin to the csv.
 
 ## Scraper
@@ -40,9 +40,12 @@ pip install -r requirements.txt
 Simple e2e test:
 
 ```
+# executes script on interval
 ./run.sh
 ```
 
 * Run `node btc_bot.js` to dump to csv
 * Creates the graph with `write_graph.py` from csv
-* Sends the graph to Slack with `send_slack.js`
+* Sends the graph to Slack with `send_slack.js`, on the crossing of some threshold. Or, simply query the public directory GET: `$HOME/public_html/$PNG_PATH`
+
+NOTE: If you're running on the OCF, install node via nvm.

--- a/btc_bot.js
+++ b/btc_bot.js
@@ -2,7 +2,8 @@ const rp = require('request-promise');
 const fs = require('fs')
 var csvWriter = require('csv-write-stream')
 
-const {CMC_PRO_API_KEY} = require('./config.js')
+const {CMC_PRO_API_KEYS} = require('./config.js')
+const RAND_KEY = CMC_PRO_API_KEYS[Math.floor(Math.random() * CMC_PRO_API_KEYS.length)]
 
 const CSV_PATH = process.env.CSV_PATH;
 
@@ -22,7 +23,7 @@ const requestOptions = {
     'convert': 'USD'
   },
   headers: {
-    'X-CMC_PRO_API_KEY': CMC_PRO_API_KEY
+    'X-CMC_PRO_API_KEY': RAND_KEY
   },
   json: true,
   gzip: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,14 @@
         "uri-js": "^4.2.2"
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -72,6 +80,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "csv-write-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/csv-write-stream/-/csv-write-stream-2.0.0.tgz",
+      "integrity": "sha1-/C2iGkjW6l+MF/3jnPuRHk8CkrA=",
+      "requires": {
+        "argparse": "^1.0.7",
+        "generate-object-property": "^1.0.0",
+        "ndjson": "^1.3.0"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -129,6 +147,19 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -160,6 +191,11 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -218,6 +254,24 @@
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
         "mime-db": "1.43.0"
+      }
+    },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "oauth-sign": {
@@ -301,6 +355,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "^2.0.2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -321,6 +388,64 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        }
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -366,6 +491,11 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+cycler==0.10.0
+kiwisolver==1.1.0
+matplotlib==3.0.3
+numpy==1.18.1
+pandas==0.25.3
+pkg-resources==0.0.0
+pyparsing==2.4.6
+python-dateutil==2.8.1
+pytz==2019.3
+scipy==1.4.1
+seaborn==0.9.1
+six==1.14.0

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CSV_PATH="$HOME/public_html/btc-usd.csv"
+export PNG_PATH="$HOME/public_html/btc-usd.png"
+
+node btc_bot.js
+
+python write_graph.py
+
+node send_slack.js

--- a/run.sh
+++ b/run.sh
@@ -41,6 +41,6 @@ do
 
     # node send_slack.js >> $LOG_PATH
 
-    log "Sleeping $SLEEP_SECS seconds..."
+    log "Sleeping $SLEEP_SECS seconds..." >> $LOG_PATH
     sleep $SLEEP_SECS
 done

--- a/send_slack.js
+++ b/send_slack.js
@@ -7,10 +7,10 @@ const slackOptions = {
     uri: SLACK_WEBHOOK,
     body: {
         // hardcoded for now lol
-        text: "text https://www.ocf.berkeley.edu/~rustielin/btc-usd.png",
-        fallback: "fallback https://www.ocf.berkeley.edu/~rustielin/btc-usd.png",
-        image_url: 'https://www.ocf.berkeley.edu/~rustielin/btc-usd.png',
-        thumb_url: 'https://www.ocf.berkeley.edu/~rustielin/btc-usd.png',
+        text: "text: " + process.env.PNG_PATH,
+        fallback: "fallback: " + process.env.PNG_PATH,
+        image_url: process.env.PNG_PATH,
+        thumb_url: process.env.PNG_PATH,
     },
     json: true,
 }

--- a/send_slack.js
+++ b/send_slack.js
@@ -1,0 +1,21 @@
+const rp = require('request-promise');
+
+const { SLACK_WEBHOOK } = require('./config.js')
+
+const slackOptions = {
+    method: 'POST',
+    uri: SLACK_WEBHOOK,
+    body: {
+        // hardcoded for now lol
+        text: "text https://www.ocf.berkeley.edu/~rustielin/btc-usd.png",
+        fallback: "fallback https://www.ocf.berkeley.edu/~rustielin/btc-usd.png",
+        image_url: 'https://www.ocf.berkeley.edu/~rustielin/btc-usd.png',
+        thumb_url: 'https://www.ocf.berkeley.edu/~rustielin/btc-usd.png',
+    },
+    json: true,
+}
+rp(slackOptions).then(response => {
+    console.log('Sent to Slack', response);
+}).catch((err) => {
+    console.log('Slack send error:', err.message);
+});

--- a/write_graph.py
+++ b/write_graph.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+import pandas as pd 
+import seaborn as sns
+import matplotlib.pyplot as plt 
+import os
+
+from datetime import datetime
+
+CSV_PATH = os.getenv('CSV_PATH')
+PNG_PATH = os.getenv('PNG_PATH')
+
+pricedf = pd.read_csv(CSV_PATH, parse_dates=['timestamp'])
+
+fig, ax = plt.subplots(figsize=(10, 10))
+
+g = sns.lineplot(ax=ax, x="timestamp", y="price", marker="o", data=pricedf)
+
+ax.set_xticks(pricedf["timestamp"])
+ax.set_xticklabels([x.strftime('%Y-%m-%d\n %H:%M:%S') for x in pricedf["timestamp"]], rotation=50)
+plt.title('Price of BTC over time')
+
+fig.savefig(PNG_PATH)
+
+print(pricedf)

--- a/write_graph.py
+++ b/write_graph.py
@@ -5,21 +5,30 @@ import seaborn as sns
 import matplotlib.pyplot as plt 
 import os
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
+from pytz import timezone
 
 CSV_PATH = os.getenv('CSV_PATH')
 PNG_PATH = os.getenv('PNG_PATH')
 
+# load in the DF
 pricedf = pd.read_csv(CSV_PATH, parse_dates=['timestamp'])
+pricedf = pricedf.set_index("timestamp")
 
+# get the last 24 hours only
+start = datetime.now(tz=timezone('UTC'))
+end = (start - timedelta(days=1))
+pricedf = pricedf[(pricedf.index >= end ) & (pricedf.index <= start)]
+
+# init 
 fig, ax = plt.subplots(figsize=(10, 10))
 
-g = sns.lineplot(ax=ax, x="timestamp", y="price", marker="o", data=pricedf)
-
-ax.set_xticks(pricedf["timestamp"])
-ax.set_xticklabels([x.strftime('%Y-%m-%d\n %H:%M:%S') for x in pricedf["timestamp"]], rotation=50)
+# make the graph
+g = sns.lineplot(ax=ax, x=pricedf.index, y="price", marker="o", data=pricedf)
+ax.set_xticks(pricedf.index) # not sure if needed
+ax.set_xticklabels([x.strftime('%Y-%m-%d\n %H:%M:%S') for x in pricedf.index], rotation=50)
 plt.title('Price of BTC over time')
 
+# write to file and log
 fig.savefig(PNG_PATH)
-
 print(pricedf)


### PR DESCRIPTION
Wrote a little scraper that will query the latest BTC-USD prices, log them to a CSV file, and other scripts to parse and generate graphs. Automated sending of data to Slack disabled for now, so we can write other hooks

**Includes breaking changes**

* Require `CMC_PRO_API_KEYS` (plural) in `./config.js` now to get the higher API rate limit we want
* Require virtualenvs for `python3` via `./run.sh` script automation
* Require node installation via `nvm` through the OCF

